### PR TITLE
[FE] - 실시간 캔들차트 중복데이터 패칭 수정

### DIFF
--- a/src/app/routes/trade.$ticker.tsx
+++ b/src/app/routes/trade.$ticker.tsx
@@ -83,7 +83,7 @@ export default function TradeRouteComponent({
 					<CoinPriceWithName name={coinInfo?.name} ticker={coinInfo?.ticker} />
 				)}
 				<div className="scrollbar-hide relative flex h-[calc(100dvh-116px)] flex-col gap-4 overflow-y-scroll p-4 md:grid md:grid-cols-2 md:grid-rows-5 xl:grid-cols-3 xl:grid-rows-2 2xl:grid-cols-4 2xl:grid-rows-2">
-					<div className="h-auto md:col-span-full md:row-span-2 md:row-start-1 xl:col-span-full xl:row-span-1 xl:row-start-1 2xl:col-span-2 2xl:col-start-2 2xl:row-start-1">
+					<div className="h-auto min-h-75 md:col-span-full md:row-span-2 md:row-start-1 xl:col-span-full xl:row-span-1 xl:row-start-1 2xl:col-span-2 2xl:col-start-2 2xl:row-start-1">
 						<Container>
 							<ContainerTitle>실시간 차트</ContainerTitle>
 							<Suspense fallback="차트데이터를 가져오고 있습니다.">

--- a/src/features/tradeview/const/chart.const.ts
+++ b/src/features/tradeview/const/chart.const.ts
@@ -7,3 +7,5 @@ export const INTERVALS = [
 ];
 
 export const INTERVAL_SELECTOR_HEIGHT = 26;
+
+export const MINUTE = 60;

--- a/src/features/tradeview/ui/Orderbook/chart.tsx
+++ b/src/features/tradeview/ui/Orderbook/chart.tsx
@@ -1,6 +1,7 @@
 import * as am5 from '@amcharts/amcharts5';
 import * as am5xy from '@amcharts/amcharts5/xy';
 import { useEffect, useLayoutEffect, useRef } from 'react';
+import { formatCurrencyKR } from '~/shared/utils';
 import type { OrderBookUnit } from '../../types/orderbook.type';
 
 const THEME = {
@@ -33,7 +34,7 @@ export default function OrderbookChart({
 		if (!chartRef.current || !yAxisRef.current || !seriesRef.current) return;
 
 		const formattedData = data.map((item) => ({
-			price: item.price.toString(),
+			price: formatCurrencyKR(+item.price),
 			size: item.size,
 			priceY: item.price,
 			sizeX: item.size,
@@ -41,10 +42,6 @@ export default function OrderbookChart({
 
 		yAxisRef.current.data.setAll(formattedData);
 		seriesRef.current.data.setAll(formattedData);
-
-		chartRef.current.series.each((series) => {
-			series.appear(1000);
-		});
 	}, [data]);
 
 	useLayoutEffect(() => {
@@ -69,7 +66,6 @@ export default function OrderbookChart({
 			am5.Rectangle.new(rootRef.current, {
 				stroke: am5.color('#fff'),
 				strokeOpacity: 0,
-				fill: THEME[type].barColor,
 				fillOpacity: 0.05,
 			}),
 		);
@@ -116,7 +112,7 @@ export default function OrderbookChart({
 				sequencedInterpolation: true,
 				tooltip: am5.Tooltip.new(rootRef.current, {
 					pointerOrientation: 'horizontal',
-					labelText: '[bold]{priceY}원 {sizeX}개',
+					labelText: "[bold]{priceY.formatNumber('#,###.##')}원 {sizeX}개",
 				}),
 				paddingBottom: 0,
 				paddingTop: 0,

--- a/src/features/tradeview/ui/StockChart/Series.tsx
+++ b/src/features/tradeview/ui/StockChart/Series.tsx
@@ -15,7 +15,6 @@ import {
 	useContext,
 	useImperativeHandle,
 	useLayoutEffect,
-	useMemo,
 	useRef,
 } from 'react';
 
@@ -113,13 +112,6 @@ export default function Series<T extends SeriesType>({
 	}, [seriesOption]);
 
 	useImperativeHandle(ref, () => seriesApiRef.current.getInstance(), []);
-
-	const context = useMemo(
-		() => ({
-			series: seriesApiRef.current,
-		}),
-		[],
-	);
 
 	return (
 		<SeriesContext.Provider value={seriesApiRef.current}>

--- a/src/features/tradeview/ui/StockChart/ToolTip.tsx
+++ b/src/features/tradeview/ui/StockChart/ToolTip.tsx
@@ -1,6 +1,7 @@
 import type { CandlestickData } from 'lightweight-charts';
 import { useLayoutEffect, useRef } from 'react';
 import { formatCurrencyKR } from '~/shared/utils';
+import { formatDateKr } from '../../utils';
 import { useChartContainer } from './ChartContainer';
 import { useChartRoot } from './ChartRoot';
 import { useSeries } from './Series';
@@ -36,6 +37,8 @@ export default function ToolTip() {
 				const { close, high, low, open, time } = param.seriesData.get(
 					chartSeries,
 				) as CandlestickData;
+				const date = new Date((time as number) * 1000);
+				const koreanDate = new Date(date.setHours(date.getHours() - 9));
 
 				toolTipElementRef.current.style.display = 'block';
 				toolTipElementRef.current.innerHTML = `<div style="border: 1px solid #d1d5db; background-color: white; padding: 0.5rem; border-radius: 0.5rem; box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05); color: #1f2937; z-index: 40;">
@@ -50,7 +53,7 @@ export default function ToolTip() {
 				<div style="font-weight: 500;">${formatCurrencyKR(close)}원</div>
 			</div>
 			<div style="border-top: 1px solid #e5e7eb; padding-top: 0.25rem; margin-top: 0.25rem;">
-				<div style="color: #6b7280; font-size: 0.75rem; line-height: 1rem;">${new Date((time as number) * 1000).toLocaleString()}</div>
+				<div style="color: #6b7280; font-size: 0.75rem; line-height: 1rem;">${formatDateKr(koreanDate)}</div>
 			</div>
 		</div>`;
 

--- a/src/features/tradeview/ui/StockChart/index.tsx
+++ b/src/features/tradeview/ui/StockChart/index.tsx
@@ -21,10 +21,14 @@ import Series from './Series';
 import ToolTip from './ToolTip';
 
 import api from '../../api/tradeview.endpoints';
-import { INTERVALS } from '../../const/chart.const';
+import { INTERVALS, MINUTE } from '../../const/chart.const';
 import usePastTimeData from '../../hooks/usePastTimeData';
 import useRealTimeData from '../../hooks/useRealTimeData';
-import { extractCandlestickData, timestampToISOString } from '../../utils';
+import {
+	extractCandlestickData,
+	priceFormatter,
+	timestampToISOString,
+} from '../../utils';
 import IntervalSelector from '../IntervalSelector';
 
 type ChartProps = {
@@ -47,6 +51,7 @@ export default function Chart({ ticker = 'BTC', count = 30 }: ChartProps) {
 			localization: {
 				locale: 'kr',
 				dateFormat: 'yyyy-MM-dd',
+				priceFormatter: priceFormatter(),
 			},
 			rightPriceScale: {
 				borderVisible: false,
@@ -144,12 +149,12 @@ export default function Chart({ ticker = 'BTC', count = 30 }: ChartProps) {
 
 		const timeDiff = +realTimeData.time - +latestTime.time;
 
-		if (timeDiff < 60 * selectedInterval) {
+		if (timeDiff < MINUTE * selectedInterval) {
 			seriesRef.current?.update({ ...realTimeData, time: latestTime.time });
 		} else {
 			seriesRef.current?.update({
 				...realTimeData,
-				time: (+latestTime.time + 60 * selectedInterval) as Time,
+				time: (+latestTime.time + MINUTE * selectedInterval) as Time,
 			});
 		}
 	}, [realTimeData, selectedInterval]);

--- a/src/features/tradeview/utils/index.ts
+++ b/src/features/tradeview/utils/index.ts
@@ -29,3 +29,19 @@ export function timestampToISOString(timestamp: number) {
 	const date = new Date(timestamp * 1000);
 	return date.toISOString().slice(0, -1);
 }
+
+export function priceFormatter() {
+	const currentLocale = window.navigator.languages[0];
+
+	return Intl.NumberFormat(currentLocale, {
+		style: 'currency',
+		currency: 'KRW',
+	}).format;
+}
+
+export function formatDateKr(date: Date) {
+	return Intl.DateTimeFormat('ko-KR', {
+		dateStyle: 'full',
+		timeStyle: 'short',
+	}).format(date);
+}


### PR DESCRIPTION
## 📝 요약(Summary)
### 실시간 캔들차트 중복데이터 패칭 수정
`VisibleLogicalRangeChange`이벤트를 사용하여 무한스크롤을 구현하였는데, 이전에 서버에 요청한 값을 중복으로 요청하는 문제가 발생했습니다.

이를 해결하기 위해 이전에 요청했던 기준 날짜(커서)를 저장하고 이를 사용해서 중복 요청을 막았습니다.
```typescript

if (
	prevRequestDate.current &&
	prevRequestDate.current <= firstData.time
)
	return;
prevRequestDate.current = firstData.time;

```

### 캔들 차트 및 호가창 스타일 수정
- 호가창의 백그라운드 색상 제거
- 호가창 애니메이션 제거
- 호가창 가격 format 적용
- 캔들차트 툴팁 날짜 format 적용 
- 캔들차트 최소 높이 적용 (모바일 화면에서 작은 높이를 가지는 문제 수정)

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ]  새로운 기능 추가   
- [x]  버그 수정   
- [x]  CSS 등 사용자 UI 디자인 변경  
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링  
- [ ]  주석 추가 및 수정  
- [ ]  테스트 추가, 테스트 리팩토링  
- [ ]  빌드 부분 혹은 패키지 매니저 수정  
- [ ]  문서 수정  
- [ ]  파일 혹은 폴더 수정/삭제  
<br/>

## 💬 공유사항 to 리뷰어
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
<br/>   

## 📸스크린샷 (선택)
<br/>     

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x]  커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ]  변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).